### PR TITLE
Improve Flatland planner with slack-based prioritization

### DIFF
--- a/piglet-public/question3.py
+++ b/piglet-public/question3.py
@@ -1,14 +1,28 @@
 
 from lib_piglet.utils.tools import eprint
 from typing import List, Tuple
-import glob, os, sys,time,json
+import glob, os, sys, time, json
+from collections import deque
 
-#import necessary modules that this python scripts need.
+# import necessary modules that this python scripts need.
+# The evaluation environment used in the assignment ships a module
+# `flatland.utils.controller`.  The open source `flatland-rl` package
+# does not include it, so during local testing the import may fail.  We
+# therefore keep the import inside a ``try`` block to allow the file to
+# be syntax‑checked even without the evaluation package installed.
 try:
     from flatland.core.transition_map import GridTransitionMap
     from flatland.envs.agent_utils import EnvAgent
-    from flatland.utils.controller import get_action, Train_Actions, Directions, check_conflict, path_controller, evaluator, remote_evaluator
-except Exception as e:
+    from flatland.utils.controller import (
+        get_action,
+        Train_Actions,
+        Directions,
+        check_conflict,
+        path_controller,
+        evaluator,
+        remote_evaluator,
+    )
+except Exception as e:  # pragma: no cover - handled in testing environment
     eprint("Cannot load flatland modules!")
     eprint(e)
     exit(1)
@@ -38,67 +52,124 @@ test = 0
 #########################
 
 
-# This function return a list of location tuple as the solution.
+def _manhattan(a: Tuple[int, int], b: Tuple[int, int]) -> int:
+    """Simple Manhattan distance used for agent prioritisation."""
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def _slack(agent: EnvAgent, max_timestep: int) -> int:
+    """Compute slack = deadline - EDT - distance."""
+    latest = agent.latest_arrival if agent.latest_arrival is not None else max_timestep
+    return latest - agent.earliest_departure - _manhattan(agent.initial_position, agent.target)
+
+
+def _is_reserved(res_pos, res_edge, from_pos, to_pos, time) -> bool:
+    """Check vertex and edge conflicts in the reservation tables."""
+    if res_pos.get((to_pos[0], to_pos[1], time)):
+        return True
+    if res_edge.get((from_pos, to_pos, time)) or res_edge.get((to_pos, from_pos, time)):
+        return True
+    return False
+
+
+def _reserve_path(res_pos, res_edge, path: List[Tuple[int, int]], start_time: int = 0) -> None:
+    """Reserve cells and edges for a computed path from ``start_time``."""
+    for i in range(len(path)):
+        t = start_time + i
+        pos = path[i]
+        res_pos[(pos[0], pos[1], t)] = True
+        if i > 0:
+            res_edge[(path[i - 1], pos, t)] = True
+
+
+def _search_single(rail: GridTransitionMap, start_pos: Tuple[int, int], start_dir: int,
+                   target: Tuple[int, int], res_pos, res_edge, start_time: int,
+                   max_timestep: int) -> List[Tuple[int, int]]:
+    """Breadth first search in time-space avoiding existing reservations."""
+    q = deque([(start_pos, start_dir, start_time, [start_pos])])
+    visited = {(start_pos, start_dir, start_time)}
+
+    while q:
+        pos, direction, t, path = q.popleft()
+        if pos == target:
+            return path
+        if t >= max_timestep - 1:
+            continue
+
+        next_time = t + 1
+
+        # Option 1: wait in place
+        if not _is_reserved(res_pos, res_edge, pos, pos, next_time):
+            state = (pos, direction, next_time)
+            if state not in visited:
+                visited.add(state)
+                q.append((pos, direction, next_time, path + [pos]))
+
+        # Option 2: move along any valid transition
+        valid_transitions = rail.get_transitions(pos[0], pos[1], direction)
+        for nd in range(len(valid_transitions)):
+            if not valid_transitions[nd]:
+                continue
+            nx, ny = pos
+            if nd == Directions.NORTH:
+                nx -= 1
+            elif nd == Directions.EAST:
+                ny += 1
+            elif nd == Directions.SOUTH:
+                nx += 1
+            elif nd == Directions.WEST:
+                ny -= 1
+            new_pos = (nx, ny)
+            if _is_reserved(res_pos, res_edge, pos, new_pos, next_time):
+                continue
+            state = (new_pos, nd, next_time)
+            if state in visited:
+                continue
+            visited.add(state)
+            q.append((new_pos, nd, next_time, path + [new_pos]))
+
+    # No path found – remain in place
+    return [start_pos]
+
+
+# This function returns a list of location tuples as the solution.
 # @param env The flatland railway environment
 # @param agents A list of EnvAgent.
 # @param max_timestep The max timestep of this episode.
 # @return path A list of (x,y) tuple.
-def get_path(agents: List[EnvAgent],rail: GridTransitionMap, max_timestep: int):
-    ############
-    # Below is an dummy path finding implementation,
-    # which always choose the first available transition of current state.
-    #
-    # Replace these with your implementation and return a list of paths. Each path is a list of (x,y) tuple as your plan.
-    # Your plan should avoid conflicts with each other.
-    ############
+def get_path(agents: List[EnvAgent], rail: GridTransitionMap, max_timestep: int):
+    # Reservation tables for vertices and edges
+    res_pos = {}
+    res_edge = {}
 
-    # initialize path list
-    path_all = []
+    n_agents = len(agents)
+    paths = [None] * n_agents
 
-    # for each agent in env
-    for agent_id in range(0,len(agents)):
-        path = []
-        loc = agents[agent_id].initial_position
-        direction = agents[agent_id].initial_direction
+    # Prioritise agents using slack-based ordering
+    order = sorted(range(n_agents), key=lambda i: _slack(agents[i], max_timestep))
 
+    for agent_id in order:
+        agent = agents[agent_id]
+        start_time = max(0, agent.earliest_departure)
+        path = _search_single(
+            rail,
+            agent.initial_position,
+            agent.initial_direction,
+            agent.target,
+            res_pos,
+            res_edge,
+            start_time,
+            max_timestep,
+        )
 
-        for t in range(0, int(max_timestep/10)):
-            # add loc to path list
-            path.append(loc)
-            if loc == agents[agent_id].target:
-                break
+        full_path = [agent.initial_position] * start_time + path
+        if len(full_path) < max_timestep:
+            full_path = full_path + [full_path[-1]] * (max_timestep - len(full_path))
 
-            # get available transitions from Rail_Env object.
-            valid_transitions = rail.get_transitions(loc[0],loc[1],direction)
-            for i in range(0,len(valid_transitions)):
-                if valid_transitions[i]:
-                    new_x=loc[0]
-                    new_y=loc[1]
-                    action = i
-                    if action == Directions.NORTH:
-                        new_x -= 1
-                    elif action == Directions.EAST:
-                        new_y += 1
-                    elif action == Directions.SOUTH:
-                        new_x += 1
-                    elif action == Directions.WEST:
-                        new_y -= 1
+        paths[agent_id] = full_path
+        _reserve_path(res_pos, res_edge, path, start_time)
 
-                    conflict = False
-                    for p in path_all:
-                        if t+1 < len(p) and p[t+1] == (new_x,new_y):
-                            conflict = True
-                        if t+1 < len(p) and p[t+1] ==(loc[0],loc[1]) and  p[t] ==(new_x,new_y):
-                            conflict = True
-                    if conflict:
-                        continue
-
-                    loc = (new_x,new_y)
-                    direction = action
-                    break
-        path_all.append(path)
-
-    return path_all
+    return paths
 
 # This function return a list of location tuple as the solution.
 # @param rail The flatland railway GridTransitionMap
@@ -110,9 +181,78 @@ def get_path(agents: List[EnvAgent],rail: GridTransitionMap, max_timestep: int):
 # @param failed_agents  The id of agents failed to reach the location on its path at current timestep.
 # @return path_all  Return paths that locaitons from current_timestp is updated to handle malfunctions and failed execuations.
 def replan(agents: List[EnvAgent],rail: GridTransitionMap,  current_timestep: int, existing_paths: List[Tuple], max_timestep:int, new_malfunction_agents: List[int], failed_agents: List[int]):
-    if debug:
-        print("Replan function not implemented yet!",file=sys.stderr)
-    return existing_paths
+    affected = set(new_malfunction_agents) | set(failed_agents)
+    if not affected:
+        return existing_paths
+
+    # Build reservation tables from unaffected agents
+    res_pos = {}
+    res_edge = {}
+    for idx, path in enumerate(existing_paths):
+        if idx in affected:
+            continue
+        if current_timestep < len(path):
+            _reserve_path(res_pos, res_edge, path[current_timestep:], current_timestep)
+
+    new_paths = existing_paths[:]
+    for idx in sorted(affected, key=lambda i: _slack(agents[i], max_timestep)):
+        agent = agents[idx]
+        start_time = max(current_timestep, agent.earliest_departure)
+        if len(existing_paths[idx]) > start_time:
+            start = existing_paths[idx][start_time]
+            if start_time > 0:
+                prev = existing_paths[idx][start_time - 1]
+                dx, dy = start[0] - prev[0], start[1] - prev[1]
+                if dx == -1:
+                    direction = Directions.NORTH
+                elif dy == 1:
+                    direction = Directions.EAST
+                elif dx == 1:
+                    direction = Directions.SOUTH
+                elif dy == -1:
+                    direction = Directions.WEST
+                else:
+                    direction = agent.initial_direction
+            else:
+                direction = agent.initial_direction
+            prefix = existing_paths[idx][:start_time]
+        else:
+            start = existing_paths[idx][-1]
+            if len(existing_paths[idx]) >= 2:
+                prev = existing_paths[idx][-2]
+                dx, dy = start[0] - prev[0], start[1] - prev[1]
+                if dx == -1:
+                    direction = Directions.NORTH
+                elif dy == 1:
+                    direction = Directions.EAST
+                elif dx == 1:
+                    direction = Directions.SOUTH
+                elif dy == -1:
+                    direction = Directions.WEST
+                else:
+                    direction = agent.initial_direction
+            else:
+                direction = agent.initial_direction
+            prefix = existing_paths[idx]
+
+        replanned = _search_single(
+            rail,
+            start,
+            direction,
+            agent.target,
+            res_pos,
+            res_edge,
+            start_time,
+            max_timestep,
+        )
+
+        full_path = prefix + replanned[1:]
+        if len(full_path) < max_timestep:
+            full_path = full_path + [full_path[-1]] * (max_timestep - len(full_path))
+        new_paths[idx] = full_path
+        _reserve_path(res_pos, res_edge, full_path[start_time:], start_time)
+
+    return new_paths
 
 
 #####################################################################


### PR DESCRIPTION
## Summary
- Implement slack-based agent priority and earliest-departure-aware path planning
- Replan routine now reschedules affected agents using the same slack metric

## Testing
- `python -m py_compile piglet-public/question3.py`
- `python piglet-public/question3.py` *(fails: No module named 'flatland.utils.controller')*


------
https://chatgpt.com/codex/tasks/task_e_68b7b0f7bad483228b1c1c66e37f7d71