### PR TITLE
Implement SIPP-based planning with LNS

### DIFF
--- a/piglet-public/question3.py
+++ b/piglet-public/question3.py
@@ -1,7 +1,6 @@
-
 from lib_piglet.utils.tools import eprint
 from typing import List, Tuple
-import glob, os, sys, time, json
+import glob, os, sys, time, json, random
 from collections import deque
 
 # import necessary modules that this python scripts need.
@@ -10,7 +9,7 @@ from collections import deque
 # does not include it, so during local testing the import may fail.  We
 # therefore keep the import inside a ``try`` block to allow the file to
 # be syntax‑checked even without the evaluation package installed.
-try:
+try:  # pragma: no cover - handled in testing environment
     from flatland.core.transition_map import GridTransitionMap
     from flatland.envs.agent_utils import EnvAgent
     from flatland.utils.controller import (
@@ -22,12 +21,10 @@ try:
         evaluator,
         remote_evaluator,
     )
-except Exception as e:  # pragma: no cover - handled in testing environment
+except Exception as e:  # pragma: no cover
     eprint("Cannot load flatland modules!")
     eprint(e)
     exit(1)
-
-
 
 
 #########################
@@ -44,17 +41,45 @@ level = 0
 test = 0
 
 #########################
-# Reimplementing the content in get_path() function and replan() function.
-#
-# They both return a list of paths. A path is a list of (x,y) location tuples.
-# The path should be conflict free.
-# Hint, you could use some global variables to reuse many resources across get_path/replan frunction calls.
+# Helper utilities
 #########################
+
+# Global caches reused between get_path and replan
+_agent_deadlines: List[int] = []
+_agent_edts: List[int] = []
+_agent_speeds: List[int] = []
+_agent_slacks: List[int] = []
 
 
 def _manhattan(a: Tuple[int, int], b: Tuple[int, int]) -> int:
-    """Simple Manhattan distance used for agent prioritisation."""
+    """Simple Manhattan distance used for heuristics."""
     return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def _get_deadline(agent: EnvAgent, default: int) -> int:
+    """Return expected arrival time if available."""
+    for attr in ("latest_arrival", "deadline", "expected_time"):
+        if hasattr(agent, attr):
+            return getattr(agent, attr)
+    return default
+
+
+def _get_edt(agent: EnvAgent) -> int:
+    """Earliest departure time."""
+    for attr in ("earliest_departure", "start_time", "earliest_start"):
+        if hasattr(agent, attr):
+            return getattr(agent, attr)
+    return 0
+
+
+def _get_speed(agent: EnvAgent) -> int:
+    """Return discrete speed counter (Cmax)."""
+    if hasattr(agent, "speed_data") and isinstance(agent.speed_data, dict):
+        if "speed" in agent.speed_data and agent.speed_data["speed"] != 0:
+            return int(round(1 / agent.speed_data["speed"]))
+    if hasattr(agent, "speed") and agent.speed:
+        return int(round(1 / agent.speed)) if agent.speed <= 1 else int(agent.speed)
+    return 1
 
 
 def _is_reserved(res_pos, res_edge, from_pos, to_pos, time) -> bool:
@@ -76,15 +101,26 @@ def _reserve_path(res_pos, res_edge, path: List[Tuple[int, int]], start_time: in
             res_edge[(path[i - 1], pos, t)] = True
 
 
-def _search_single(rail: GridTransitionMap, start_pos: Tuple[int, int], start_dir: int,
-                   target: Tuple[int, int], res_pos, res_edge, start_time: int,
-                   max_timestep: int) -> List[Tuple[int, int]]:
-    """Breadth first search in time-space avoiding existing reservations."""
-    q = deque([(start_pos, start_dir, start_time, [start_pos])])
-    visited = {(start_pos, start_dir, start_time)}
+def _search_sipp(
+    rail: GridTransitionMap,
+    start_pos: Tuple[int, int],
+    start_dir: int,
+    target: Tuple[int, int],
+    res_pos,
+    res_edge,
+    start_time: int,
+    earliest_departure: int,
+    speed_cmax: int,
+    max_timestep: int,
+):
+    """SIPP-like search with discrete speeds and reservations."""
+
+    t0 = max(start_time, earliest_departure)
+    q = deque([(start_pos, start_dir, t0, 0, [start_pos])])
+    visited = {(start_pos, start_dir, t0, 0)}
 
     while q:
-        pos, direction, t, path = q.popleft()
+        pos, direction, t, counter, path = q.popleft()
         if pos == target:
             return path
         if t >= max_timestep - 1:
@@ -92,95 +128,171 @@ def _search_single(rail: GridTransitionMap, start_pos: Tuple[int, int], start_di
 
         next_time = t + 1
 
-        # Option 1: wait in place
+        # Wait in place
         if not _is_reserved(res_pos, res_edge, pos, pos, next_time):
-            state = (pos, direction, next_time)
+            new_counter = min(counter + 1, speed_cmax - 1)
+            state = (pos, direction, next_time, new_counter)
             if state not in visited:
                 visited.add(state)
-                q.append((pos, direction, next_time, path + [pos]))
+                q.append((pos, direction, next_time, new_counter, path + [pos]))
 
-        # Option 2: move along any valid transition
-        valid_transitions = rail.get_transitions(pos[0], pos[1], direction)
-        for nd in range(len(valid_transitions)):
-            if not valid_transitions[nd]:
-                continue
-            nx, ny = pos
-            if nd == Directions.NORTH:
-                nx -= 1
-            elif nd == Directions.EAST:
-                ny += 1
-            elif nd == Directions.SOUTH:
-                nx += 1
-            elif nd == Directions.WEST:
-                ny -= 1
-            new_pos = (nx, ny)
-            if _is_reserved(res_pos, res_edge, pos, new_pos, next_time):
-                continue
-            state = (new_pos, nd, next_time)
-            if state in visited:
-                continue
-            visited.add(state)
-            q.append((new_pos, nd, next_time, path + [new_pos]))
+        # Move if speed counter allows
+        if counter + 1 >= speed_cmax:
+            valid_transitions = rail.get_transitions(pos[0], pos[1], direction)
+            for nd in range(len(valid_transitions)):
+                if not valid_transitions[nd]:
+                    continue
+                nx, ny = pos
+                if nd == Directions.NORTH:
+                    nx -= 1
+                elif nd == Directions.EAST:
+                    ny += 1
+                elif nd == Directions.SOUTH:
+                    nx += 1
+                elif nd == Directions.WEST:
+                    ny -= 1
+                new_pos = (nx, ny)
+                if _is_reserved(res_pos, res_edge, pos, new_pos, next_time):
+                    continue
+                state = (new_pos, nd, next_time, 0)
+                if state in visited:
+                    continue
+                visited.add(state)
+                q.append((new_pos, nd, next_time, 0, path + [new_pos]))
 
     # No path found – remain in place
     return [start_pos]
 
 
-# This function returns a list of location tuples as the solution.
-# @param env The flatland railway environment
-# @param agents A list of EnvAgent.
-# @param max_timestep The max timestep of this episode.
-# @return path A list of (x,y) tuple.
-def get_path(agents: List[EnvAgent], rail: GridTransitionMap, max_timestep: int):
-    # Reservation tables for vertices and edges
-    res_pos = {}
-    res_edge = {}
+def _arrival_time(path: List[Tuple[int, int]], goal: Tuple[int, int]) -> int:
+    for t, p in enumerate(path):
+        if p == goal:
+            return t
+    return len(path)
 
-    n_agents = len(agents)
-    paths = [None] * n_agents
 
-    # Prioritise agents with shorter Manhattan distance to goal
-    order = sorted(range(n_agents), key=lambda i: _manhattan(agents[i].initial_position, agents[i].target))
+def _total_delay(paths: List[List[Tuple[int, int]]], agents: List[EnvAgent]) -> int:
+    total = 0
+    for i, path in enumerate(paths):
+        deadline = _agent_deadlines[i]
+        at = _arrival_time(path, agents[i].target)
+        total += max(0, at - deadline)
+    return total
 
-    for agent_id in order:
-        agent = agents[agent_id]
-        path = _search_single(
-            rail,
-            agent.initial_position,
-            agent.initial_direction,
-            agent.target,
-            res_pos,
-            res_edge,
-            0,
-            max_timestep,
-        )
 
-        # Extend the path by waiting at the goal to avoid later collisions
-        if len(path) < max_timestep:
-            path = path + [path[-1]] * (max_timestep - len(path))
+def _lns_improve(paths, agents, rail, max_timestep, iterations=20):
+    """Delay-based neighbourhood selection for LNS optimisation."""
+    global _agent_slacks
 
-        paths[agent_id] = path
-        _reserve_path(res_pos, res_edge, path)
+    for _ in range(iterations):
+        late = [i for i in range(len(agents)) if _arrival_time(paths[i], agents[i].target) > _agent_deadlines[i]]
+        if not late:
+            break
+        seed = random.choice(late)
+        neighbourhood = {seed}
+        seed_path = paths[seed]
+        for t, pos in enumerate(seed_path):
+            for j, p in enumerate(paths):
+                if j == seed:
+                    continue
+                if t < len(p) and p[t] == pos:
+                    neighbourhood.add(j)
+        subset = list(neighbourhood)
+
+        res_pos, res_edge = {}, {}
+        for idx, p in enumerate(paths):
+            if idx in neighbourhood:
+                continue
+            _reserve_path(res_pos, res_edge, p)
+
+        new_paths = paths[:]
+        order = sorted(subset, key=lambda i: (_agent_slacks[i], _agent_speeds[i]))
+        for idx in order:
+            a = agents[idx]
+            p = _search_sipp(
+                rail,
+                a.initial_position,
+                a.initial_direction,
+                a.target,
+                res_pos,
+                res_edge,
+                0,
+                _agent_edts[idx],
+                _agent_speeds[idx],
+                max_timestep,
+            )
+            if len(p) < max_timestep:
+                p = p + [p[-1]] * (max_timestep - len(p))
+            new_paths[idx] = p
+            _reserve_path(res_pos, res_edge, p)
+
+        if _total_delay(new_paths, agents) < _total_delay(paths, agents):
+            paths = new_paths
 
     return paths
 
-# This function return a list of location tuple as the solution.
-# @param rail The flatland railway GridTransitionMap
-# @param agents A list of EnvAgent.
-# @param current_timestep The timestep that malfunction/collision happens .
-# @param existing_paths The existing paths from previous get_plan or replan.
-# @param max_timestep The max timestep of this episode.
-# @param new_malfunction_agents  The id of agents have new malfunction happened at current time step (Does not include agents already have malfunciton in past timesteps)
-# @param failed_agents  The id of agents failed to reach the location on its path at current timestep.
-# @return path_all  Return paths that locaitons from current_timestp is updated to handle malfunctions and failed execuations.
-def replan(agents: List[EnvAgent],rail: GridTransitionMap,  current_timestep: int, existing_paths: List[Tuple], max_timestep:int, new_malfunction_agents: List[int], failed_agents: List[int]):
+
+# ---------------------------------------------------------------------------
+# Planning entry points
+# ---------------------------------------------------------------------------
+
+
+def get_path(agents: List[EnvAgent], rail: GridTransitionMap, max_timestep: int):
+    global _agent_deadlines, _agent_edts, _agent_speeds, _agent_slacks
+
+    n_agents = len(agents)
+    _agent_deadlines = [_get_deadline(a, max_timestep) for a in agents]
+    _agent_edts = [_get_edt(a) for a in agents]
+    _agent_speeds = [_get_speed(a) for a in agents]
+    _agent_slacks = [
+        _agent_deadlines[i] - _agent_edts[i] - _manhattan(agents[i].initial_position, agents[i].target)
+        for i in range(n_agents)
+    ]
+
+    res_pos, res_edge = {}, {}
+    paths = [None] * n_agents
+
+    order = sorted(range(n_agents), key=lambda i: (_agent_slacks[i], _agent_speeds[i]))
+
+    for idx in order:
+        a = agents[idx]
+        path = _search_sipp(
+            rail,
+            a.initial_position,
+            a.initial_direction,
+            a.target,
+            res_pos,
+            res_edge,
+            0,
+            _agent_edts[idx],
+            _agent_speeds[idx],
+            max_timestep,
+        )
+        if len(path) < max_timestep:
+            path = path + [path[-1]] * (max_timestep - len(path))
+        paths[idx] = path
+        _reserve_path(res_pos, res_edge, path)
+
+    # Large neighbourhood search to reduce delays
+    paths = _lns_improve(paths, agents, rail, max_timestep)
+
+    return paths
+
+
+def replan(
+    agents: List[EnvAgent],
+    rail: GridTransitionMap,
+    current_timestep: int,
+    existing_paths: List[List[Tuple[int, int]]],
+    max_timestep: int,
+    new_malfunction_agents: List[int],
+    failed_agents: List[int],
+):
     affected = set(new_malfunction_agents) | set(failed_agents)
     if not affected:
         return existing_paths
 
-    # Build reservation tables from unaffected agents
-    res_pos = {}
-    res_edge = {}
+    res_pos, res_edge = {}, {}
     for idx, path in enumerate(existing_paths):
         if idx in affected:
             continue
@@ -190,45 +302,31 @@ def replan(agents: List[EnvAgent],rail: GridTransitionMap,  current_timestep: in
     new_paths = existing_paths[:]
     for idx in affected:
         agent = agents[idx]
-        if len(existing_paths[idx]) > current_timestep:
+        if current_timestep < len(existing_paths[idx]):
             start = existing_paths[idx][current_timestep]
-            if current_timestep > 0 and len(existing_paths[idx]) >= 2:
+            if current_timestep > 0:
                 prev = existing_paths[idx][current_timestep - 1]
-                dx, dy = start[0] - prev[0], start[1] - prev[1]
-                if dx == -1:
-                    direction = Directions.NORTH
-                elif dy == 1:
-                    direction = Directions.EAST
-                elif dx == 1:
-                    direction = Directions.SOUTH
-                elif dy == -1:
-                    direction = Directions.WEST
-                else:
-                    direction = agent.initial_direction
             else:
-                direction = agent.initial_direction
-            prefix = existing_paths[idx][:current_timestep]
+                prev = start
         else:
-            # agent already finished path; restart from last position
             start = existing_paths[idx][-1]
-            if len(existing_paths[idx]) >= 2:
-                prev = existing_paths[idx][-2]
-                dx, dy = start[0] - prev[0], start[1] - prev[1]
-                if dx == -1:
-                    direction = Directions.NORTH
-                elif dy == 1:
-                    direction = Directions.EAST
-                elif dx == 1:
-                    direction = Directions.SOUTH
-                elif dy == -1:
-                    direction = Directions.WEST
-                else:
-                    direction = agent.initial_direction
-            else:
-                direction = agent.initial_direction
-            prefix = existing_paths[idx]
+            prev = existing_paths[idx][-1]
 
-        replanned = _search_single(
+        dx, dy = start[0] - prev[0], start[1] - prev[1]
+        if dx == -1:
+            direction = Directions.NORTH
+        elif dy == 1:
+            direction = Directions.EAST
+        elif dx == 1:
+            direction = Directions.SOUTH
+        elif dy == -1:
+            direction = Directions.WEST
+        else:
+            direction = agent.initial_direction
+
+        prefix = existing_paths[idx][:current_timestep]
+
+        replanned = _search_sipp(
             rail,
             start,
             direction,
@@ -236,18 +334,23 @@ def replan(agents: List[EnvAgent],rail: GridTransitionMap,  current_timestep: in
             res_pos,
             res_edge,
             current_timestep,
+            max(_agent_edts[idx], current_timestep),
+            _agent_speeds[idx],
             max_timestep,
         )
 
-        # Merge prefix and new plan
         full_path = prefix + replanned[1:]
         if len(full_path) < max_timestep:
             full_path = full_path + [full_path[-1]] * (max_timestep - len(full_path))
         new_paths[idx] = full_path
         _reserve_path(res_pos, res_edge, full_path[current_timestep:], current_timestep)
 
+    # Optional improvement pass on affected agents
+    subset_agents = [agents[i] for i in range(len(agents))]
+    new_paths = _lns_improve(new_paths, agents, rail, max_timestep, iterations=10)
+
     return new_paths
- 
+
 
 #####################################################################
 # Instantiate a Remote Client
@@ -256,17 +359,16 @@ def replan(agents: List[EnvAgent],rail: GridTransitionMap,  current_timestep: in
 if __name__ == "__main__":
 
     if len(sys.argv) > 1:
-        remote_evaluator(get_path,sys.argv, replan = replan)
+        remote_evaluator(get_path, sys.argv, replan=replan)
     else:
         script_path = os.path.dirname(os.path.abspath(__file__))
         test_cases = glob.glob(os.path.join(script_path, "multi_test_case/level*_test_*.pkl"))
 
         if test_single_instance:
-            test_cases = glob.glob(os.path.join(script_path,"multi_test_case/level{}_test_{}.pkl".format(level, test)))
+            test_cases = glob.glob(
+                os.path.join(script_path, "multi_test_case/level{}_test_{}.pkl".format(level, test))
+            )
         test_cases.sort()
-        deadline_files =  [test.replace(".pkl",".ddl") for test in test_cases]
-        evaluator(get_path, test_cases, debug, visualizer, 3, deadline_files, replan = replan)
-
-
-
+        deadline_files = [test.replace(".pkl", ".ddl") for test in test_cases]
+        evaluator(get_path, test_cases, debug, visualizer, 3, deadline_files, replan=replan)
 


### PR DESCRIPTION
## Summary
- add slack-based prioritized planning with discrete-speed SIPP
- incorporate delay-driven large neighbourhood search for path improvement
- support SIPP-based replanning after malfunctions

## Testing
- `python piglet-public/question3.py` *(fails: No module named 'flatland.utils.controller')*

------
https://chatgpt.com/codex/tasks/task_e_68b7d29e9e648322b446a8b07a859839